### PR TITLE
Timestamp at top center

### DIFF
--- a/css/suchedule.css
+++ b/css/suchedule.css
@@ -467,6 +467,7 @@ tr > td:first-child, th:first-child {
 
 .hour-cell {
     font-weight: bold;
+    display: grid;
 }
 
 #schedule th:nth-child(even), td:nth-child(even) {


### PR DESCRIPTION
Move time to the top of the box to better indicate it's the start time of the time block.
Too be fair, this might be super obvious to some students, but as an exchange student this confused me more than once when I created my schedule

### before
![before](https://user-images.githubusercontent.com/64368773/210435774-64f46dd1-e825-47dc-9823-129cb8d9baf3.png)

### after
![after](https://user-images.githubusercontent.com/64368773/210435793-6f3441c7-1dcf-4c99-8572-47cae3606b84.png)
